### PR TITLE
msm8998-common: enable cpuidle during boot

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -50,7 +50,6 @@ BOARD_KERNEL_PAGESIZE := 4096
 
 BOARD_KERNEL_CMDLINE := androidboot.console=ttyMSM0 androidboot.hardware=qcom
 BOARD_KERNEL_CMDLINE += user_debug=31 msm_rtb.filter=0x37 ehci-hcd.park=3
-BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 BOARD_KERNEL_CMDLINE += service_locator.enable=1
 BOARD_KERNEL_CMDLINE += swiotlb=2048
 

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -132,7 +132,6 @@ on init
     write /sys/module/lpm_levels/system/pwr/pwr-l2-ret/idle_enabled N
     write /sys/module/lpm_levels/system/perf/perf-l2-dynret/idle_enabled N
     write /sys/module/lpm_levels/system/perf/perf-l2-ret/idle_enabled N
-    write /sys/module/lpm_levels/parameters/sleep_disabled N
 
     # Create camera daemon cpusets
     mkdir /dev/cpuset/camera-daemon 0750 cameraserver cameraserver
@@ -224,7 +223,6 @@ on charger
     write /sys/devices/system/cpu/cpu6/online 0
     write /sys/devices/system/cpu/cpu7/online 0
     write /sys/module/msm_thermal/parameters/enabled N
-    write /sys/module/lpm_levels/parameters/sleep_disabled N
 
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "userspace"
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq 300000


### PR DESCRIPTION
This is only used to keep cpuidle disabled during boot, which is
unnecessary and doesn't really improve boot times (but does incur a high
power cost).

Change-Id: Id5878edd58a59de36da9bf9381262cabd3f3cb4b
Signed-off-by: Sultan Alsawaf <sultanxda@gmail.com>